### PR TITLE
release - 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All changes from version 1.1.1 will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.2] - 2021-04-25
+- fix KafkaLimitAckSinkSemantics `promise already completed` error
+- add new `openFile` and `getLinesIterator` api to filesystem source semantics
+- add new `IO` utils for simple file IO operations
+
 ## [2.4.1] - 2021-03-08
 - add new config for directory watch source for handle large line
 - fix http pool bufferoverflow

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val common = Seq(
   /* master branch stable version => 2.2.1 (current)
    *   version := "2.2.1", */
   /* develop branch unstable test 2.3.x => stable release 2.4.x */
-  version := "2.4.1",
+  version := "2.4.2",
   scalaVersion := "2.11.12",
 
   /* BuildPaths.defaultGlobalBase => ~/.sbt */

--- a/core/src/main/scala/atiesh/utils/IO.scala
+++ b/core/src/main/scala/atiesh/utils/IO.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) Hao Feng
+ */
+
+package atiesh.utils
+
+// java
+import java.io.{ File => JFile, InputStream, FileInputStream,
+                 InputStreamReader, BufferedReader }
+// scala
+import scala.io.{ Codec, Source }
+import scala.collection.{ Iterator, AbstractIterator }
+import scala.collection.mutable.StringBuilder
+
+object IO {
+  val DEFAULT_EXPECTED_LINE_LENGTH = 80
+  val DEFAULT_LINE_SEPARATOR = '\n'
+  val DEFAULT_BUF_SIZE = 8192
+  val DEFAULT_MAX_LINE_LENGTH = 512 * 1024 * 1024 /* assumed 2 bytes pre char */
+
+  def createIOSource(rawStream: InputStream,
+                     bufferSize: Int,
+                     resetFn: () => IOSource,
+                     closeFn: () => Unit)(implicit codec: Codec): IOSource =
+    new IOSource(rawStream, bufferSize)(codec)
+      .withReset(resetFn)
+      .withClose(closeFn)
+
+  def fromFile(path: JFile,
+               bufferSize: Int)(implicit codec: Codec): IOSource = {
+    val rawInputStream = new FileInputStream(path)
+    createIOSource(rawInputStream,
+                   bufferSize, 
+                   () => fromFile(path, bufferSize)(codec),
+                   () => rawInputStream.close())(codec)
+  }
+
+  def fromFile(path: JFile)(implicit codec: Codec): IOSource =
+    fromFile(path, DEFAULT_BUF_SIZE)(codec)
+
+  def fromFile(name: String,
+               bufferSize: Int)(implicit codec: Codec): IOSource = {
+    fromFile(new JFile(name), bufferSize)
+  }
+
+  def fromFile(name: String)(implicit codec: Codec): IOSource = {
+    fromFile(new JFile(name))
+  }
+}
+
+class IOSource(rawStream: InputStream,
+               bufferSize: Int)(implicit codec: Codec) extends Source {
+  def this(rawStream: InputStream)(implicit codec: Codec) =
+    this(rawStream, IO.DEFAULT_BUF_SIZE)(codec)
+
+  final private[this] val charReader =
+    new InputStreamReader(rawStream, codec.decoder)
+  final private[this] val bufferedCharReader =
+    new BufferedReader(charReader, bufferSize)
+
+  /* scala io.Source iter */
+  override val iter = Iterator.continually(codec.wrap(bufferedCharReader.read()))
+                              .takeWhile(_ != -1)
+                              .map(_.toChar)
+
+  class LineIterator(lineSeparator: Char,
+                     lineExpectedLength: Int,
+                     lineMaxLength: Int)
+    extends AbstractIterator[String] with Iterator[String] {
+    def this() = this(IO.DEFAULT_LINE_SEPARATOR,
+                      IO.DEFAULT_EXPECTED_LINE_LENGTH,
+                      IO.DEFAULT_MAX_LINE_LENGTH)
+ 
+    var nextLine: String = null
+    private def readLine(): String =
+      iter.takeWhile(_ != lineSeparator)
+          .foldLeft(
+            new StringBuilder(IO.DEFAULT_EXPECTED_LINE_LENGTH))((sb, c) => {
+              if (sb.length() < lineMaxLength) sb.append(c)
+              sb
+            }).toString
+
+    override def hasNext(): Boolean = {
+      if (nextLine == null) {
+        nextLine = readLine()
+      }
+      nextLine != null
+    }
+    
+    override def next(): String =
+      if (hasNext()) {
+        try nextLine
+        finally nextLine = null
+      } else {
+        throw new NoSuchElementException("next on empty iterator")
+      }
+  }
+
+  def getLines(lineSeparator: Char,
+               lineExpectedLength: Int,
+               lineMaxLength: Int): Iterator[String] =
+    new LineIterator(lineSeparator, lineExpectedLength, lineMaxLength)
+  override def getLines(): Iterator[String] = new LineIterator()
+}

--- a/semantics-filesystem/src/main/scala/atiesh/source/DirectoryWatchSource.scala
+++ b/semantics-filesystem/src/main/scala/atiesh/source/DirectoryWatchSource.scala
@@ -6,6 +6,9 @@ package atiesh.source
 
 // java
 import java.nio.file.Path
+// scala
+import scala.io.{ Codec, Source => IOSource }
+import scala.collection.Iterator
 // internal
 import atiesh.interceptor.Interceptor
 import atiesh.sink.Sink
@@ -19,8 +22,17 @@ class DirectoryWatchSource(name: String,
                            strategy: String)
   extends AtieshSource(name, dispatcher, cfg, interceptors, sinks, strategy)
   with ActiveSourceSemantics
-  with DirectoryWatchSourceSemantics 
+  with DirectoryWatchSourceSemantics
   with Logging {
+  import DirectoryWatchSourceSemantics.scalaFileOpener
+
+  def openFile(path: String,
+               codec: Codec): IOSource =
+    scalaFileOpener(path, codec)
+
+  def getLinesIterator(stream: IOSource,
+                       offset: Int): Iterator[String] =
+    stream.getLines().drop(offset)
 
   def skipFile(path: Path): Boolean = false
 

--- a/semantics-http/src/main/scala/atiesh/source/HttpSource.scala
+++ b/semantics-http/src/main/scala/atiesh/source/HttpSource.scala
@@ -84,8 +84,7 @@ class HttpSource(name: String,
           Compressor.gzipDecompress(req.body.toArray) match {
             case Success(bs) => Some(new String(bs, cfgReqCodec))
             case Failure(exc) =>
-              throw new HttpBadRequestException(
-                s"got unexcepted exception while decompress gzip request", exc)
+              throw new HttpBadRequestException(exc.getMessage, exc)
           }
         } else {
           throw new HttpBadRequestException(


### PR DESCRIPTION
- fix KafkaLimitAckSinkSemantics `promise already completed` error
- add new `openFile` and `getLinesIterator` api to filesystem source semantics
- add new `IO` utils for simple file IO operations