### PR TITLE
develop - 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.3] - Not Release Yet
 - add custom delimiter opt to http source impl
+- update deps,
+  - akka-http 10.1.13 -> 10.1.15 (latest of 10.1.x)
+  - config 1.3.3 -> 1.4.1 (latest)
+  - kamon 2.0.4 -> 2.0.5 (latest of 2.0.x)
+  - scala-logging 3.9.0 -> 3.9.4 (latest)
+  - slf4j-api 1.7.29 -> 1.7.32 (latest)
+  - scala kafka to java kafka-clients 2.4.1
+- change kafka `poll` invoke
+- add `getJDuration` to *Configuration* class for read java duration object
 
 ## [2.4.2] - 2021-04-25
 - fix KafkaLimitAckSinkSemantics `promise already completed` error

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,6 @@ import sbt.Keys.{ credentials, publishTo }
 
 lazy val common = Seq(
   organization := "io.0ops",
-  /* master branch stable version => 2.2.1 (current)
-   *   version := "2.2.1", */
-  /* develop branch unstable test 2.3.x => stable release 2.4.x */
   version := "2.4.2",
   scalaVersion := "2.11.12",
 
@@ -35,16 +32,15 @@ lazy val dependencies = Seq(
     // akka-actor
     "com.typesafe.akka"          %% "akka-actor"           % "2.5.32",
     // typesafe config
-    "com.typesafe"               %  "config"               % "1.3.3",
+    "com.typesafe"               %  "config"               % "1.4.1",
     // kamon
-    "io.kamon"                   %% "kamon-core"           % "2.0.4",
-    /* kamon utils dependency for test only */
+    "io.kamon"                   %% "kamon-core"           % "2.0.5",
     "io.kamon"                   %% "kamon-system-metrics" % "2.0.1",
     "io.kamon"                   %% "kamon-prometheus"     % "2.0.1",
     // logger
-    "org.slf4j"                   % "slf4j-api"            % "1.7.29",
+    "org.slf4j"                   % "slf4j-api"            % "1.7.32",
     "ch.qos.logback"              % "logback-classic"      % "1.2.3", // scalalogging docs
-    "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.0"
+    "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.4"
 ).map(_.excludeAll(ExclusionRule("io.kamon", "kamon-core_2.11"),
                    ExclusionRule("com.typesafe", "config"),
                    ExclusionRule("org.slf4j", "slf4j-api")))
@@ -64,9 +60,20 @@ lazy val httputils = (project in file("utils/http"))
     name := "atiesh-utils-http",
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream" % "2.5.32",
-      "com.typesafe.akka" %% "akka-http" % "10.1.13",
+      "com.typesafe.akka" %% "akka-http" % "10.1.15",
     )
   ).dependsOn(core)
+
+/* atiesh semantics - http */
+lazy val http = (project in file("semantics-http"))
+  .settings(
+    common,
+    name := "atiesh-semantics-http",
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-stream" % "2.5.26",
+      "com.typesafe.akka" %% "akka-http" % "10.1.10"
+    )
+  ).dependsOn(httputils)
 
 /* atiesh semantics - files */
 lazy val filesystem = (project in file("semantics-filesystem"))
@@ -82,23 +89,10 @@ lazy val kafka = (project in file("semantics-kafka"))
     common,
     name := "atiesh-semantics-kafka",
     libraryDependencies ++= Seq(
-      "org.apache.kafka" %% "kafka" % "1.1.1"
-        exclude("org.slf4j", "slf4j-api")
-        exclude("com.typesafe.scala-logging", "scala-logging_2.11")
-        exclude("com.typesafe.scala-logging", "scala-logging_2.12"),
+      "org.apache.kafka" % "kafka-clients" % "2.4.1"
+        exclude("org.slf4j", "slf4j-api"),
     )
   ).dependsOn(core)
-
-/* atiesh semantics - http */
-lazy val http = (project in file("semantics-http"))
-  .settings(
-    common,
-    name := "atiesh-semantics-http",
-    libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream" % "2.5.26",
-      "com.typesafe.akka" %% "akka-http" % "10.1.10"
-    )
-  ).dependsOn(httputils)
 
 /*
  * atiesh semantics - syslog (experiment),
@@ -114,7 +108,7 @@ lazy val syslog = (project in file("semantics-syslog"))
     common,
     name := "atiesh-semantics-syslog",
     libraryDependencies ++= Seq(
-      "com.cloudbees" % "syslog-java-client" % "1.1.4"
+      "com.cloudbees" % "syslog-java-client" % "1.1.7"
     )
   ).dependsOn(core)
 

--- a/core/src/main/scala/atiesh/utils/Configuration.scala
+++ b/core/src/main/scala/atiesh/utils/Configuration.scala
@@ -4,6 +4,8 @@
 
 package atiesh.utils
 
+// java
+import java.time.{ Duration => JDuration }
 // scala
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
@@ -128,6 +130,13 @@ case class Configuration(cfg: Config) {
     getValueOption(path)(p => {
       Duration.fromNanos(cfg.getDuration(p).toNanos)
     })
+
+  def getJDuration(path: String): JDuration =
+    getValue(path)(p => { cfg.getDuration(p) })
+  def getJDuration(path: String, default: JDuration): JDuration =
+    getValue(path, default)(p => { cfg.getDuration(p) })
+  def getJDurationOption(path: String): Option[JDuration] =
+    getValueOption(path)(p => { cfg.getDuration(p) })
 }
 
 object Configuration {


### PR DESCRIPTION
- update deps,
  - akka-http 10.1.13 -> 10.1.15 (latest of 10.1.x)
  - config 1.3.3 -> 1.4.1 (latest)
  - kamon 2.0.4 -> 2.0.5 (latest of 2.0.x)
  - scala-logging 3.9.0 -> 3.9.4 (latest)
  - slf4j-api 1.7.29 -> 1.7.32 (latest)
  - scala kafka to java kafka-clients 2.4.1
- change kafka `poll` invoke
- add `getJDuration` to *Configuration* class for read java duration object