### PR TITLE
release - 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes from version 1.1.1 will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.4.3] - Not Release Yet
+## [2.4.3] - 2021-12-07
 - add custom delimiter opt to http source impl
 - update deps,
   - akka-http 10.1.13 -> 10.1.15 (latest of 10.1.x)

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbt.Keys.{ credentials, publishTo }
 
 lazy val common = Seq(
   organization := "io.0ops",
-  version := "2.4.2",
+  version := "2.4.3",
   scalaVersion := "2.11.12",
 
   /* BuildPaths.defaultGlobalBase => ~/.sbt */


### PR DESCRIPTION
## [2.4.3] - 2021-12-07
- add custom delimiter opt to http source impl
- update deps,
  - akka-http 10.1.13 -> 10.1.15 (latest of 10.1.x)
  - config 1.3.3 -> 1.4.1 (latest)
  - kamon 2.0.4 -> 2.0.5 (latest of 2.0.x)
  - scala-logging 3.9.0 -> 3.9.4 (latest)
  - slf4j-api 1.7.29 -> 1.7.32 (latest)
  - scala kafka to java kafka-clients 2.4.1
- change kafka `poll` invoke
- add `getJDuration` to *Configuration* class for read java duration object