### PR TITLE
 stability improves of http semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All changes from version 1.1.1 will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.5]
+- bug fix, any exception throw inside `runFold` for response body reading no longer shutdown the http stream
+- bug fix, graceful shutdown of `BatchSinkSemantics` was properly handled
+- bug fix, now http can use proper dispatcher initialize stream `ActorMaterializer`
+- improvement, http source now raise `HttpTooManyRequestException` instead of block the client forever
+- improvement, new hooks for connect accept and terminate for http source
+
 ## [2.4.4] - 2021-12-27
 - add simple PKI utils
 - add default syslog sink component

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val dependencies = Seq(
 ).map(_.excludeAll(ExclusionRule("io.kamon", "kamon-core_2.11"),
                    ExclusionRule("com.typesafe", "config"),
                    ExclusionRule("org.slf4j", "slf4j-api")))
+lazy val showDepsJars = taskKey[Unit]("dependencies classpath (local jar files) of the current project.")
 
 /* atiesh core framework */
 lazy val core = (project in file("core"))
@@ -83,7 +84,12 @@ lazy val http = (project in file("semantics-http"))
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream" % "2.5.26",
       "com.typesafe.akka" %% "akka-http" % "10.1.10"
-    )
+    ),
+    showDepsJars := {
+      (Compile / externalDependencyClasspath).value
+        .map(_.data)    /* List[java.io.File] */
+        .foreach(file => { println(file.toString) })
+    }
   ).dependsOn(httputils)
 
 /* atiesh semantics - files */
@@ -91,7 +97,12 @@ lazy val filesystem = (project in file("semantics-filesystem"))
   .settings(
     common,
     name := "atiesh-semantics-filesystem",
-    libraryDependencies ++= dependencies
+    libraryDependencies ++= dependencies,
+    showDepsJars := {
+      (Compile / externalDependencyClasspath).value
+        .map(_.data)    /* List[java.io.File] */
+        .foreach(file => { println(file.toString) })
+    }
   ).dependsOn(core)
 
 /* atiesh semantics - kafka */
@@ -102,7 +113,12 @@ lazy val kafka = (project in file("semantics-kafka"))
     libraryDependencies ++= Seq(
       "org.apache.kafka" % "kafka-clients" % "2.4.1"
         exclude("org.slf4j", "slf4j-api"),
-    )
+    ),
+    showDepsJars := {
+      (Compile / externalDependencyClasspath).value
+        .map(_.data)    /* List[java.io.File] */
+        .foreach(file => { println(file.toString) })
+    }
   ).dependsOn(core)
 
 /**
@@ -120,7 +136,12 @@ lazy val syslog = (project in file("semantics-syslog"))
     name := "atiesh-semantics-syslog",
     libraryDependencies ++= Seq(
       "com.cloudbees" % "syslog-java-client" % "1.1.7"
-    )
+    ),
+    showDepsJars := {
+      (Compile / externalDependencyClasspath).value
+        .map(_.data)    /* List[java.io.File] */
+        .foreach(file => { println(file.toString) })
+    }
   ).dependsOn(core)
 
 /**
@@ -141,5 +162,10 @@ lazy val aliyun = (project in file("semantics-aliyun"))
       "com.aliyun.openservices" % "aliyun-log-producer" % "0.2.0"
         exclude("org.slf4j", "slf4j-api") exclude("org.slf4j", "slf4j-log4j12")
         exclude("ch.qos.logback", "logback-core") exclude("ch.qos.logback", "logback-classic"),
-    )
+    ),
+    showDepsJars := {
+      (Compile / externalDependencyClasspath).value
+        .map(_.data)    /* List[java.io.File] */
+        .foreach(file => { println(file.toString) })
+    }
   ).dependsOn(core)

--- a/semantics-http/src/main/scala/atiesh/source/Exceptions.scala
+++ b/semantics-http/src/main/scala/atiesh/source/Exceptions.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Hao Feng
+ */
+
+package atiesh.source
+
+// internal
+import atiesh.utils.http.HttpRequest
+
+object HttpTooManyRequestException {
+  def unapply(exc: HttpTooManyRequestException): Option[(Option[HttpRequest], Option[Throwable])] = {
+    exc match {
+      case e: HttpTooManyRequestException => Some(e.request, e.cause)
+      case _ => None
+    }
+  }
+}
+
+class HttpTooManyRequestException(val message: String,
+                                  val request: Option[HttpRequest],
+                                  val cause: Option[Throwable]) extends RuntimeException(message, cause.getOrElse(null)) {
+  def this(message: String) = this(message, None, None)
+  def this(message: String, cause: Throwable) = this(message, None, Some(cause))
+  def this(message: String, request: HttpRequest) = this(message, Some(request), None)
+  def this(message: String, request: HttpRequest, cause: Throwable) = this(message, Some(request), Some(cause))
+  def this(cause: Throwable) = this(null, None, Some(cause))
+  def this() = this(null, None, None)
+}

--- a/semantics-kafka/src/main/scala/atiesh/sink/KafkaLimitAckSinkSemantics.scala
+++ b/semantics-kafka/src/main/scala/atiesh/sink/KafkaLimitAckSinkSemantics.scala
@@ -175,9 +175,13 @@ trait KafkaLimitAckSinkSemantics
        * handle other illegal signals.
        */
       case _ =>
-        logger.error("kafka sink semantics of sink <{}> got illegal " +
-                     "signal num <{}> which means you may use a " +
-                     "kafka sink with wrong implementation", getName, sig)
+        if (sig < 0) {
+          super.process(sig)  /* passing-through core signals */
+        } else {
+          logger.error("kafka sink semantics of sink <{}> got illegal " +
+                       "signal num <{}> which means you may use a " +
+                       "kafka sink with wrong implementation", getName, sig)
+        }
     }
   }
 

--- a/semantics-kafka/src/main/scala/atiesh/sink/KafkaSynchronousAckSinkSemantics.scala
+++ b/semantics-kafka/src/main/scala/atiesh/sink/KafkaSynchronousAckSinkSemantics.scala
@@ -135,9 +135,13 @@ trait KafkaSynchronousAckSinkSemantics
        * handle other illegal signals.
        */
       case _ =>
-        logger.error("kafka synchronous ack sink semantics of sink <{}> got " +
-                     "illegal signal num <{}> which means you may use a " +
-                     "kafka sink with wrong implementation", getName, sig)
+        if (sig < 0) {
+          super.process(sig)  /* passing-through core signals */
+        } else {
+          logger.error("kafka synchronous ack sink semantics of sink <{}> got " +
+                       "illegal signal num <{}> which means you may use a " +
+                       "kafka sink with wrong implementation", getName, sig)
+        }
     }
   }
 


### PR DESCRIPTION
- bug fix, any exception throw inside `runFold` for response body reading no longer shutdown the http stream
- bug fix, graceful shutdown of `BatchSinkSemantics` was properly handled
- bug fix, now http can use proper dispatcher initialize stream `ActorMaterializer`
- improvement, http source now raise `HttpTooManyRequestException` instead of block the client forever
- improvement, new hooks for connect accept and terminate for http source