### PR TITLE
stability improves of kafka semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.5]
 - bug fix, any exception throw inside `runFold` for response body reading no longer shutdown the http stream
+- bug fix, handle exception thrown by `pruducer.send`
 - bug fix, graceful shutdown of `BatchSinkSemantics` was properly handled
+- bug fix, graceful shutdown of `KafkaLimitAckSinkSemantics` was properly handled
 - bug fix, now http can use proper dispatcher initialize stream `ActorMaterializer`
 - improvement, http source now raise `HttpTooManyRequestException` instead of block the client forever
 - improvement, new hooks for connect accept and terminate for http source


### PR DESCRIPTION
- bug fix, handle exception thrown by `pruducer.send`
- bug fix, graceful shutdown of `KafkaLimitAckSinkSemantics` was properly handled