### PR TITLE
release - v2.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes from version 1.1.1 will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.4.5]
+## [2.4.5] - 2022-03-07
 - bug fix, any exception throw inside `runFold` for response body reading no longer shutdown the http stream
 - bug fix, handle exception thrown by `pruducer.send`
 - bug fix, graceful shutdown of `BatchSinkSemantics` was properly handled

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbt.Keys.{ credentials, publishTo }
 
 lazy val common = Seq(
   organization := "io.0ops",
-  version := "2.4.4",
+  version := "2.4.5",
   scalaVersion := "2.11.12",
 
   /**


### PR DESCRIPTION
## [2.4.5] - 2022-03-07
- bug fix, any exception throw inside `runFold` for response body reading no longer shutdown the http stream
- bug fix, handle exception thrown by `pruducer.send`
- bug fix, graceful shutdown of `BatchSinkSemantics` was properly handled
- bug fix, graceful shutdown of `KafkaLimitAckSinkSemantics` was properly handled
- bug fix, now http can use proper dispatcher initialize stream `ActorMaterializer`
- improvement, http source now raise `HttpTooManyRequestException` instead of block the client forever
- improvement, new hooks for connect accept and terminate for http source